### PR TITLE
Unvanquished 0.52.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+Unvanquished flatpak
+====================
+
+This repository provides the sources for building the Unvanquished flatpak package. The built game can be found on [Flathub](https://flathub.org/apps/details/net.unvanquished.Unvanquished).
+
+[Unvanquished](https://unvanquished.net/) is a free open source first-person real-time strategy game using the free open source [Dæmon](https://github.com/DaemonEngine/Daemon) game engine.
+
+- Unvanquished website: [unvanquished.net](https://unvanquished.net/),
+- Unvanquished forums: [forums.unvanquished.net](https://forums.unvanquished.net/)
+- Unvanquished wiki: [wiki.unvanquished.net](https://wiki.unvanquished.net)
+
+Contributing
+------------
+
+Bugs related to the game itself have to be reported on the game [issue tracker](https://github.com/Unvanquished/Unvanquished/issues).
+
+Packaging issues related to this flatpak have to be reported on the [issue tracker](https://github.com/flathub/net.unvanquished.Unvanquished/issues) of this repository.
+
+- Unvanquished game logic repository: [github.com/Unvanquished/Unvanquished](https://github.com/Unvanquished/Unvanquished),
+- Unvanquished game assets repository: [github.com/UnvanquishedAssets/UnvanquishedAssets](https://github.com/UnvanquishedAssets/UnvanquishedAssets),
+- Dæmon game engine repository: [github.com/DaemonEngine/Daemon](https://github.com/DaemonEngine/Daemon)

--- a/net.unvanquished.Unvanquished.metainfo.xml
+++ b/net.unvanquished.Unvanquished.metainfo.xml
@@ -23,19 +23,19 @@
 
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://unvanquished.net/wp-content/uploads/2021/04/perseus_tyrant.jpg</image>
+      <image type="source">https://unvanquished.net/wp-content/uploads/2021/06/20210619-143221-002.unvanquished-0.52.1-battlesuit-facing-tyrant.jpg</image>
     </screenshot>
     <screenshot>
       <image type="source">https://unvanquished.net/wp-content/uploads/2021/05/20210504-082658-002.unvanquished-0.52-human-builder.jpg</image>
     </screenshot>
     <screenshot>
-      <image type="source">https://unvanquished.net/wp-content/uploads/2020/09/20200909-025733-001.unvanquished-rocket-missile.jpg</image>
+      <image type="source">https://unvanquished.net/wp-content/uploads/2021/06/20200909-025733-002.unvanquished-rocket-missile.jpg</image>
     </screenshot>
     <screenshot>
       <image type="source">https://unvanquished.net/wp-content/uploads/2021/05/20210504-081116-002.unvanquished-0.52-alien-team.jpg</image>
     </screenshot>
     <screenshot>
-      <image type="source">https://unvanquished.net/wp-content/uploads/2020/09/20200909-001900-000.unvanquished-lasgun-weapon.jpg</image>
+      <image type="source">https://unvanquished.net/wp-content/uploads/2021/06/20200909-001900-002.unvanquished-lasgun-weapon.jpg</image>
     </screenshot>
     <screenshot>
       <image type="source">https://unvanquished.net/wp-content/uploads/2021/05/20210504-083923-002.unvanquished-0.52-alien-builder.jpg</image>
@@ -50,11 +50,20 @@
   <url type="help">https://wiki.unvanquished.net/wiki/Main_Page</url>
 
   <releases>
+    <release version="0.52.1" date="2021-06-20">
+      <description>
+        <p>
+          This update brings some bug fixes and marks the first point release
+          in Unvanquished 0.52 beta development cycle.
+        </p>
+      </description>
+      <url>https://unvanquished.net/unvanquished-0-52-1-better-freer-stronger/</url>
+    </release>
     <release version="0.52.0" date="2021-05-14">
       <description>
         <p>
           The first beta release, coming after years of continuous work
-          both on the engine and the game itself
+          both on the engine and the game itself.
         </p>
       </description>
       <url>https://unvanquished.net/unvanquished-0-52-beta-is-there/</url>

--- a/net.unvanquished.Unvanquished.yml
+++ b/net.unvanquished.Unvanquished.yml
@@ -20,8 +20,8 @@ modules:
       - mv pkg /app/pkg
     sources:
       - type: archive
-        url: https://dl.unvanquished.net/release/unvanquished_0.52.0.zip
-        sha256: 2af1af06426f4c2ac93be0bde122bf263ec7a2a8608df48c4f9d6aed0106f6be
+        url: https://dl.unvanquished.net/release/unvanquished_0.52.1.zip
+        sha256: 63cd62daafbedf5870951e36b665dfa90c10193fa442192e8f6cf841526e0abf
 
   - name: daemon
     buildsystem: cmake-ninja
@@ -39,14 +39,14 @@ modules:
       - -DOpenGL_GL_PREFERENCE=LEGACY # https://github.com/DaemonEngine/Daemon/issues/474
     sources:
       - type: git
-        url: https://github.com/DaemonEngine/Daemon
-        tag: unvanquished/0.52.0
+        url: https://github.com/DaemonEngine/Daemon.git
+        tag: unvanquished/0.52.1
       - type: file
         path: net.unvanquished.Unvanquished.metainfo.xml
       - type: file
         path: net.unvanquished.Unvanquished.desktop
       - type: file
-        url: https://raw.githubusercontent.com/Unvanquished/Unvanquished/master/dist/icons/512x512/unvanquished.png
+        url: https://raw.githubusercontent.com/Unvanquished/Unvanquished/e1b0a1f9a7306126940dffb94d6ced036fe970b2/dist/icons/512x512/unvanquished.png
         sha256: d49b6edb49917f7a87497129e8e71ce396027361016fac01c093fb5564f7dee1
       - type: archive
         dest: external_deps/linux64-5


### PR DESCRIPTION
If everything goes right, the 0.52.1 point release will be announced on 2021-06-20, the url of the blog post is not known yet.

As a side work I did some bikeshedding:

- I added a `.git` extension to the Dæmon engine repository,
- I replaced the branch name with the commit name in the url for the icon (this way pushing new icon can't break existing description file),
- I also added a readme to this repository (it is expected to have not impact on produced flatpak build).

This must not be merged before the blog post url is added.