### PR TITLE
Prefer wayland over X11

### DIFF
--- a/net.unvanquished.Unvanquished.yml
+++ b/net.unvanquished.Unvanquished.yml
@@ -7,8 +7,8 @@ finish-args:
   - --share=network
   - --socket=pulseaudio # sound
   - --device=dri # OpenGL
-  - --socket=wayland # Wayland access (used as a fallback by SDL if X11 fails)
-  - --socket=x11 # X11 access
+  - --socket=wayland # Wayland access
+  - --socket=fallback-x11 # Fallback to X11, if wayland isn't available 
   - --share=ipc # X shared memory, required for x11
 cleanup:
   - /share/doc


### PR DESCRIPTION
Always try to use wayland and fallback to X11 only when wayland isn't available.

This fixes the "Unvanquished is potentially unsafe" warning on flathub.